### PR TITLE
Separate auth server and resource server hostname

### DIFF
--- a/migration_scripts/v4.py
+++ b/migration_scripts/v4.py
@@ -1,0 +1,32 @@
+# TODO: some smarter way of handling migrations
+
+import apsw
+import apsw.bestpractice
+
+apsw.bestpractice.apply(apsw.bestpractice.recommended)
+
+from millipds import static_config
+
+
+def migrate(con: apsw.Connection):
+	version_now = con.execute("SELECT db_version FROM config").fetchone()[0]
+
+	assert version_now == 3
+
+	# Get current pds_pfx value to use as default for auth_pfx
+	pds_pfx = con.execute("SELECT pds_pfx FROM config").fetchone()[0]
+
+	# Add auth_pfx column
+	con.execute("ALTER TABLE config ADD COLUMN auth_pfx TEXT")
+
+	# Set auth_pfx to pds_pfx for existing installations
+	con.execute("UPDATE config SET auth_pfx=?", (pds_pfx,))
+
+	con.execute("UPDATE config SET db_version=4")
+
+
+if __name__ == "__main__":
+	with apsw.Connection(static_config.MAIN_DB_PATH) as con:
+		migrate(con)
+
+	print("v3 -> v4 Migration successful")

--- a/src/millipds/__main__.py
+++ b/src/millipds/__main__.py
@@ -1,8 +1,8 @@
 """millipds CLI
 
 Usage:
-  millipds init <hostname> [--dev | --sandbox]
-  millipds config [--pds_pfx=URL] [--pds_did=DID] [--bsky_appview_pfx=URL] [--bsky_appview_did=DID]
+  millipds init <hostname> [--dev | --sandbox] [--auth_host=HOST]
+  millipds config [--pds_pfx=URL] [--pds_did=DID] [--auth_pfx=URL] [--bsky_appview_pfx=URL] [--bsky_appview_did=DID]
   millipds account create <did> <handle> [--unsafe_password=PW] [--signing_key=PEM]
   millipds run [--sock_path=PATH] [--listen_host=HOST] [--listen_port=PORT]
   millipds util keygen [--p256 | --k256]
@@ -19,6 +19,7 @@ Init:
   hostname            The public-facing hostname of this PDS, e.g. "bsky.social"
   --dev               Pre-set config options for local dev/testing
   --sandbox           Pre-set config options to work with the bsky "sandbox" network. Otherwise, default to bsky prod.
+  --auth_host=HOST    Separate hostname for authorization server (defaults to same as PDS hostname)
 
 Config:
   Any options not specified will be left at their previous values. Once changes
@@ -28,6 +29,7 @@ Config:
 
   --pds_pfx=URL           The HTTP URL prefix that this PDS is publicly accessible at (e.g. mypds.example)
   --pds_did=DID           This PDS's DID (e.g. did:web:mypds.example)
+  --auth_pfx=URL          The HTTP URL prefix for the authorization server (e.g. https://auth.mypds.example)
   --bsky_appview_pfx=URL  AppView URL prefix e.g. "https://api.bsky-sandbox.dev"
   --bsky_appview_did=DID  AppView DID e.g. did:web:api.bsky-sandbox.dev
 
@@ -99,10 +101,12 @@ def main():
 				" or manually delete the db and try again."
 			)
 			return
+		auth_host = args["--auth_host"] or args["<hostname>"]
 		if args["--dev"]:  # like prod but http://
 			db.update_config(
 				pds_pfx=f"http://{args['<hostname>']}",
 				pds_did=f"did:web:{urllib.parse.quote(args['<hostname>'])}",
+				auth_pfx=f"http://{auth_host}",
 				bsky_appview_pfx="https://api.bsky.app",
 				bsky_appview_did="did:web:api.bsky.app",
 			)
@@ -112,6 +116,7 @@ def main():
 			db.update_config(
 				pds_pfx=f"https://{args['<hostname>']}",
 				pds_did=f"did:web:{urllib.parse.quote(args['<hostname>'])}",
+				auth_pfx=f"https://{auth_host}",
 				bsky_appview_pfx="https://api.bsky-sandbox.dev",
 				bsky_appview_did="did:web:api.bsky-sandbox.dev",
 			)
@@ -119,6 +124,7 @@ def main():
 			db.update_config(
 				pds_pfx=f"https://{args['<hostname>']}",
 				pds_did=f"did:web:{urllib.parse.quote(args['<hostname>'])}",
+				auth_pfx=f"https://{auth_host}",
 				bsky_appview_pfx="https://api.bsky.app",
 				bsky_appview_did="did:web:api.bsky.app",
 			)
@@ -203,6 +209,7 @@ def main():
 		db.update_config(
 			pds_pfx=args["--pds_pfx"],
 			pds_did=args["--pds_did"],
+			auth_pfx=args["--auth_pfx"],
 			bsky_appview_pfx=args["--bsky_appview_pfx"],
 			bsky_appview_did=args["--bsky_appview_did"],
 		)

--- a/src/millipds/auth_oauth.py
+++ b/src/millipds/auth_oauth.py
@@ -16,9 +16,16 @@ logger = logging.getLogger(__name__)
 # this is a bit of a hack to annotate routes as AS-only, to be checked via middleware
 class AnnotatedRouteTableDef(web.RouteTableDef):
 	def route(self, method: str, path: str, **kwargs):
-		fn = super().route(method, path, **kwargs)
-		setattr(fn, "_is_as_route", True)
-		return fn
+		decorator = super().route(method, path, **kwargs)
+
+		def wrapper(handler):
+			# Apply the original decorator
+			result = decorator(handler)
+			# Set the attribute on the handler (which is returned by decorator)
+			setattr(result, "_is_as_route", True)
+			return result
+
+		return wrapper
 
 
 as_routes = AnnotatedRouteTableDef()

--- a/src/millipds/database.py
+++ b/src/millipds/database.py
@@ -35,6 +35,7 @@ class MillipdsConfigPartial(TypedDict):
 	jwt_access_secret: str
 	pds_pfx: Optional[str]
 	pds_did: Optional[str]
+	auth_pfx: Optional[str]
 	bsky_appview_pfx: Optional[str]
 	bsky_appview_did: Optional[str]
 
@@ -46,6 +47,7 @@ class MillipdsConfig(TypedDict):
 	jwt_access_secret: str
 	pds_pfx: str
 	pds_did: str
+	auth_pfx: str
 	bsky_appview_pfx: str
 	bsky_appview_did: str
 
@@ -129,6 +131,7 @@ class Database:
 				db_version INTEGER NOT NULL,
 				pds_pfx TEXT,
 				pds_did TEXT,
+				auth_pfx TEXT,
 				bsky_appview_pfx TEXT,
 				bsky_appview_did TEXT,
 				jwt_access_secret TEXT NOT NULL
@@ -288,6 +291,7 @@ class Database:
 		self,
 		pds_pfx: Optional[str] = None,
 		pds_did: Optional[str] = None,
+		auth_pfx: Optional[str] = None,
 		bsky_appview_pfx: Optional[str] = None,
 		bsky_appview_did: Optional[str] = None,
 	):
@@ -296,6 +300,8 @@ class Database:
 				self.con.execute("UPDATE config SET pds_pfx=?", (pds_pfx,))
 			if pds_did is not None:
 				self.con.execute("UPDATE config SET pds_did=?", (pds_did,))
+			if auth_pfx is not None:
+				self.con.execute("UPDATE config SET auth_pfx=?", (auth_pfx,))
 			if bsky_appview_pfx is not None:
 				self.con.execute(
 					"UPDATE config SET bsky_appview_pfx=?", (bsky_appview_pfx,)
@@ -316,6 +322,7 @@ class Database:
 			"db_version",
 			"pds_pfx",
 			"pds_did",
+			"auth_pfx",
 			"bsky_appview_pfx",
 			"bsky_appview_did",
 			"jwt_access_secret",
@@ -334,6 +341,7 @@ class Database:
 				if (
 					partial["pds_pfx"] is None
 					or partial["pds_did"] is None
+					or partial["auth_pfx"] is None
 					or partial["bsky_appview_pfx"] is None
 					or partial["bsky_appview_did"] is None
 				):

--- a/src/millipds/service.py
+++ b/src/millipds/service.py
@@ -43,10 +43,10 @@ PROXY_OVERRIDE_PATHS = [
 @web.middleware
 async def atproto_service_proxy_middleware(request: web.Request, handler):
 	# if the PDS has split RS/AS config, enforce that separation
+	is_as_route = getattr(handler, "_is_as_route", False)
 	cfg = get_db(request).config
 	if cfg["auth_pfx"] != cfg["pds_pfx"]:
 		is_as_request = request.host == util.hostname_from_url(cfg["auth_pfx"])
-		is_as_route = getattr(handler, "_is_as_route", False)
 		if is_as_request != is_as_route:
 			return web.HTTPNotFound()
 
@@ -56,6 +56,7 @@ async def atproto_service_proxy_middleware(request: web.Request, handler):
 		atproto_proxy
 		and request.path not in PROXY_OVERRIDE_PATHS
 		and not request.path.startswith("/xrpc/com.atproto.")
+		and not is_as_route
 	):
 		return await service_proxy(request, atproto_proxy)
 

--- a/src/millipds/service.py
+++ b/src/millipds/service.py
@@ -42,6 +42,14 @@ PROXY_OVERRIDE_PATHS = [
 
 @web.middleware
 async def atproto_service_proxy_middleware(request: web.Request, handler):
+	# if the PDS has split RS/AS config, enforce that separation
+	cfg = get_db(request).config
+	if cfg["auth_pfx"] != cfg["pds_pfx"]:
+		is_as_request = request.host == util.hostname_from_url(cfg["auth_pfx"])
+		is_as_route = getattr(handler, "_is_as_route", False)
+		if is_as_request != is_as_route:
+			return web.HTTPNotFound()
+
 	# https://atproto.com/specs/xrpc#service-proxying
 	atproto_proxy = request.headers.get("atproto-proxy")
 	if (
@@ -485,6 +493,7 @@ def construct_app(
 	app[MILLIPDS_DID_RESOLVER] = did_resolver
 
 	app.add_routes(routes)
+	app.add_routes(auth_oauth.as_routes)
 	app.add_routes(auth_oauth.routes)
 	app.add_routes(atproto_sync.routes)
 	app.add_routes(atproto_repo.routes)

--- a/src/millipds/static_config.py
+++ b/src/millipds/static_config.py
@@ -11,7 +11,7 @@ HTTP_LOG_FMT = (
 GROUPNAME = "millipds-sock"
 
 # this gets bumped if we make breaking changes to the db schema
-MILLIPDS_DB_VERSION = 3
+MILLIPDS_DB_VERSION = 4
 
 ATPROTO_REPO_VERSION_3 = 3  # might get bumped if the atproto spec changes
 CAR_VERSION_1 = 1

--- a/src/millipds/util.py
+++ b/src/millipds/util.py
@@ -15,6 +15,7 @@ from typing import (
 	Type,
 )
 from weakref import WeakValueDictionary
+from urllib.parse import urlparse
 
 from aiohttp import web
 
@@ -26,6 +27,18 @@ from . import static_config
 
 def mkdirs_for_file(path: str) -> None:
 	os.makedirs(os.path.dirname(path), exist_ok=True)
+
+
+def hostname_from_url(url: str) -> str:
+	"""
+	Extract hostname from a URL string.
+	Examples:
+		"http://example.com" -> "example.com"
+		"https://example.com:8080" -> "example.com:8080"
+		"http://localhost:3000" -> "localhost:3000"
+	"""
+	parsed = urlparse(url)
+	return parsed.netloc
 
 
 FILANEME_SAFE_CHARS = (

--- a/src/millipds/util.py
+++ b/src/millipds/util.py
@@ -41,7 +41,7 @@ def hostname_from_url(url: str) -> str:
 	return parsed.netloc
 
 
-FILANEME_SAFE_CHARS = (
+FILENAME_SAFE_CHARS = (
 	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
 )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,7 @@ async def test_pds(aiolib):
 			db.update_config(
 				pds_pfx=f"http://{hostname}",
 				pds_did=f"did:web:{urllib.parse.quote(hostname)}",
+				auth_pfx=f"http://{hostname}",
 				bsky_appview_pfx="https://api.bsky.app",
 				bsky_appview_did="did:web:api.bsky.app",
 			)
@@ -92,6 +93,7 @@ async def test_pds(aiolib):
 			db.update_config(
 				pds_pfx=f"http://{hostname}",
 				pds_did=f"did:web:{urllib.parse.quote(hostname)}",
+				auth_pfx=f"http://{hostname}",
 				bsky_appview_pfx="https://api.bsky.app",
 				bsky_appview_did="did:web:api.bsky.app",
 			)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -14,6 +14,7 @@ def test_did_by_handle_found():
 		db.update_config(
 			pds_pfx="http://test.local",
 			pds_did="did:web:test.local",
+			auth_pfx="http://test.local",
 			bsky_appview_pfx="https://api.bsky.app",
 			bsky_appview_did="did:web:api.bsky.app",
 		)
@@ -38,6 +39,7 @@ def test_did_by_handle_not_found():
 		db.update_config(
 			pds_pfx="http://test.local",
 			pds_did="did:web:test.local",
+			auth_pfx="http://test.local",
 			bsky_appview_pfx="https://api.bsky.app",
 			bsky_appview_did="did:web:api.bsky.app",
 		)
@@ -53,6 +55,7 @@ def test_handle_by_did_found():
 		db.update_config(
 			pds_pfx="http://test.local",
 			pds_did="did:web:test.local",
+			auth_pfx="http://test.local",
 			bsky_appview_pfx="https://api.bsky.app",
 			bsky_appview_did="did:web:api.bsky.app",
 		)
@@ -77,6 +80,7 @@ def test_handle_by_did_not_found():
 		db.update_config(
 			pds_pfx="http://test.local",
 			pds_did="did:web:test.local",
+			auth_pfx="http://test.local",
 			bsky_appview_pfx="https://api.bsky.app",
 			bsky_appview_did="did:web:api.bsky.app",
 		)
@@ -92,6 +96,7 @@ def test_signing_key_pem_by_did_found():
 		db.update_config(
 			pds_pfx="http://test.local",
 			pds_did="did:web:test.local",
+			auth_pfx="http://test.local",
 			bsky_appview_pfx="https://api.bsky.app",
 			bsky_appview_did="did:web:api.bsky.app",
 		)
@@ -117,6 +122,7 @@ def test_signing_key_pem_by_did_not_found():
 		db.update_config(
 			pds_pfx="http://test.local",
 			pds_did="did:web:test.local",
+			auth_pfx="http://test.local",
 			bsky_appview_pfx="https://api.bsky.app",
 			bsky_appview_did="did:web:api.bsky.app",
 		)
@@ -132,6 +138,7 @@ def test_list_repos():
 		db.update_config(
 			pds_pfx="http://test.local",
 			pds_did="did:web:test.local",
+			auth_pfx="http://test.local",
 			bsky_appview_pfx="https://api.bsky.app",
 			bsky_appview_did="did:web:api.bsky.app",
 		)
@@ -167,6 +174,7 @@ def test_config_is_initialised():
 		db.update_config(
 			pds_pfx="http://test.local",
 			pds_did="did:web:test.local",
+			auth_pfx="http://test.local",
 			bsky_appview_pfx="https://api.bsky.app",
 			bsky_appview_did="did:web:api.bsky.app",
 		)
@@ -182,6 +190,7 @@ def test_verify_account_login_success():
 		db.update_config(
 			pds_pfx="http://test.local",
 			pds_did="did:web:test.local",
+			auth_pfx="http://test.local",
 			bsky_appview_pfx="https://api.bsky.app",
 			bsky_appview_did="did:web:api.bsky.app",
 		)
@@ -215,6 +224,7 @@ def test_verify_account_login_wrong_password():
 		db.update_config(
 			pds_pfx="http://test.local",
 			pds_did="did:web:test.local",
+			auth_pfx="http://test.local",
 			bsky_appview_pfx="https://api.bsky.app",
 			bsky_appview_did="did:web:api.bsky.app",
 		)
@@ -237,6 +247,7 @@ def test_verify_account_login_nonexistent_user():
 		db.update_config(
 			pds_pfx="http://test.local",
 			pds_did="did:web:test.local",
+			auth_pfx="http://test.local",
 			bsky_appview_pfx="https://api.bsky.app",
 			bsky_appview_did="did:web:api.bsky.app",
 		)

--- a/tests/test_split_as_rs.py
+++ b/tests/test_split_as_rs.py
@@ -1,0 +1,190 @@
+"""Tests for split Authorization Server / Resource Server configuration."""
+
+import asyncio
+import dataclasses
+import tempfile
+import urllib.parse
+
+import aiohttp
+import pytest
+
+from millipds import crypto, database, service
+from tests.conftest import (
+	TEST_DID,
+	TEST_HANDLE,
+	TEST_PASSWORD,
+	TEST_PRIVKEY,
+	VALID_LOGINS,
+	service_run_and_capture_port,
+)
+
+
+@dataclasses.dataclass
+class SplitPDSInfo:
+	endpoint: str  # Single server endpoint
+	pds_host: str  # PDS Host header value
+	auth_host: str  # Auth Host header value
+	db: database.Database
+
+
+@pytest.fixture
+async def split_pds(aiolib):
+	"""Create a test PDS instance with split AS/RS hostnames.
+
+	Uses a single server but different Host headers to simulate split hostnames.
+	"""
+	queue = asyncio.Queue()
+
+	with tempfile.TemporaryDirectory() as tempdir:
+		async with aiohttp.ClientSession() as client:
+			db_path = f"{tempdir}/millipds-0000.db"
+			db = database.Database(path=db_path)
+
+			# Start server
+			run_task = asyncio.create_task(
+				service_run_and_capture_port(
+					queue,
+					db=db,
+					client=client,
+					sock_path=None,
+					host="localhost",
+					port=0,
+				)
+			)
+			queue_get = asyncio.create_task(queue.get())
+			done, pending = await asyncio.wait(
+				(queue_get, run_task),
+				return_when=asyncio.FIRST_COMPLETED,
+			)
+			if run_task in done:
+				raise run_task.exception()  # type: ignore[misc]
+
+			port = queue_get.result()
+
+			# Configure with split hostnames (same port, different hosts)
+			pds_host = "pds.localhost"
+			auth_host = "auth.localhost"
+
+			db.update_config(
+				pds_pfx=f"http://{pds_host}",
+				pds_did=f"did:web:{urllib.parse.quote(pds_host)}",
+				auth_pfx=f"http://{auth_host}",
+				bsky_appview_pfx="https://api.bsky.app",
+				bsky_appview_did="did:web:api.bsky.app",
+			)
+
+			db.create_account(
+				did=TEST_DID,
+				handle=TEST_HANDLE,
+				password=TEST_PASSWORD,
+				privkey=TEST_PRIVKEY,
+			)
+
+			try:
+				yield SplitPDSInfo(
+					endpoint=f"http://localhost:{port}",
+					pds_host=pds_host,
+					auth_host=auth_host,
+					db=db,
+				)
+			finally:
+				db.con.close()
+				run_task.cancel()
+				try:
+					await run_task
+				except asyncio.CancelledError:
+					pass
+
+
+async def test_split_as_rs_oauth_metadata(s, split_pds):
+	"""Test that OAuth metadata endpoints are only accessible on correct hosts."""
+	# AS metadata should be accessible on auth host
+	async with s.get(
+		split_pds.endpoint + "/.well-known/oauth-authorization-server",
+		headers={"Host": split_pds.auth_host},
+	) as r:
+		assert r.status == 200
+		data = await r.json()
+		assert "issuer" in data
+
+	# AS metadata should NOT be accessible on PDS host
+	async with s.get(
+		split_pds.endpoint + "/.well-known/oauth-authorization-server",
+		headers={"Host": split_pds.pds_host},
+	) as r:
+		assert r.status == 404
+
+	# RS metadata should be accessible on PDS host
+	async with s.get(
+		split_pds.endpoint + "/.well-known/oauth-protected-resource",
+		headers={"Host": split_pds.pds_host},
+	) as r:
+		assert r.status == 200
+		data = await r.json()
+		assert data["resource"] == split_pds.db.config["pds_pfx"]
+		assert split_pds.db.config["auth_pfx"] in data["authorization_servers"]
+
+	# RS metadata should NOT be accessible on auth host
+	async with s.get(
+		split_pds.endpoint + "/.well-known/oauth-protected-resource",
+		headers={"Host": split_pds.auth_host},
+	) as r:
+		assert r.status == 404
+
+
+async def test_split_as_rs_oauth_endpoints(s, split_pds):
+	"""Test that OAuth endpoints are only accessible on auth host."""
+	# /oauth/authorize should work on auth host
+	async with s.get(
+		split_pds.endpoint + "/oauth/authorize",
+		headers={"Host": split_pds.auth_host},
+	) as r:
+		assert r.status == 200
+		text = await r.text()
+		assert "html" in text.lower()  # Should return HTML login page
+
+	# /oauth/authorize should NOT work on PDS host
+	async with s.get(
+		split_pds.endpoint + "/oauth/authorize",
+		headers={"Host": split_pds.pds_host},
+	) as r:
+		assert r.status == 404
+
+
+async def test_split_as_rs_xrpc_endpoints(s, split_pds):
+	"""Test that XRPC endpoints are only accessible on PDS host."""
+	# XRPC endpoints should work on PDS host
+	async with s.get(
+		split_pds.endpoint + "/xrpc/com.atproto.server.describeServer",
+		headers={"Host": split_pds.pds_host},
+	) as r:
+		assert r.status == 200
+
+	# XRPC endpoints should NOT work on auth host
+	async with s.get(
+		split_pds.endpoint + "/xrpc/com.atproto.server.describeServer",
+		headers={"Host": split_pds.auth_host},
+	) as r:
+		assert r.status == 404
+
+
+async def test_split_as_rs_session_creation(s, split_pds):
+	"""Test that session creation works on PDS host."""
+	# createSession should work on PDS host
+	async with s.post(
+		split_pds.endpoint + "/xrpc/com.atproto.server.createSession",
+		json=VALID_LOGINS[0],
+		headers={"Host": split_pds.pds_host},
+	) as r:
+		assert r.status == 200
+		data = await r.json()
+		assert data["did"] == TEST_DID
+		assert "accessJwt" in data
+
+	# createSession should NOT work on auth host
+	async with s.post(
+		split_pds.endpoint + "/xrpc/com.atproto.server.createSession",
+		json=VALID_LOGINS[0],
+		headers={"Host": split_pds.auth_host},
+	) as r:
+		assert r.status == 404


### PR DESCRIPTION
Adds support for configuring a separate hostname for the OAuth authorization server, distinct from the PDS resource server hostname.

- Add auth_pfx column to config table (db schema v3->v4)
- Add migration script to populate auth_pfx from pds_pfx for existing DBs
- Update init command with --auth_host option
- Update config command with --auth_pfx option
- Document nginx setup for separate auth hostname