### PR TITLE
Replace argon2-cffi with cryptography library for password hashing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
 	"aiohttp-middlewares", # cors
 	"docopt",
 	"apsw",
-	"argon2-cffi",
 	"base58"
 ]
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -254,3 +254,97 @@ def test_verify_account_login_nonexistent_user():
 
 		with pytest.raises(KeyError, match="no account found"):
 			db.verify_account_login("nonexistent.test", "anypassword")
+
+
+def test_verify_account_login_with_hardcoded_argon2_hash():
+	"""Test login with hardcoded argon2-cffi hash to ensure backward compatibility.
+
+	This test ensures that existing password hashes in the database continue
+	to work after switching from argon2-cffi to cryptography library.
+	"""
+	with tempfile.TemporaryDirectory() as tempdir:
+		db = database.Database(path=f"{tempdir}/test.db")
+		db.update_config(
+			pds_pfx="http://test.local",
+			pds_did="did:web:test.local",
+			auth_pfx="http://test.local",
+			bsky_appview_pfx="https://api.bsky.app",
+			bsky_appview_did="did:web:api.bsky.app",
+		)
+
+		# Hardcoded argon2id hash generated with argon2-cffi for password "test_password_123"
+		# Generated with: argon2.PasswordHasher().hash('test_password_123')
+		hardcoded_hash = "$argon2id$v=19$m=65536,t=3,p=4$ZTsgHf6aqSqJMtsNUaiwCw$am2lm1pd2BoLMqUGy4BrJmWTDxzX7ukUR2vkCso9jsY"
+
+		test_did = "did:plc:argon2test"
+		test_handle = "argon2.test"
+		test_password = "test_password_123"
+
+		# Create account by directly inserting into database with hardcoded hash
+		privkey = crypto.keygen_p256()
+		privkey_pem = crypto.privkey_to_pem(privkey)
+
+		# Import necessary modules for creating initial commit
+		from millipds import util, static_config
+		import cbrrr
+		from atmst.mst.node import MSTNode
+
+		with db.con:
+			tid = util.tid_now()
+			empty_mst = MSTNode.empty_root()
+			initial_commit = {
+				"did": test_did,
+				"version": static_config.ATPROTO_REPO_VERSION_3,
+				"data": empty_mst.cid,
+				"rev": tid,
+				"prev": None,
+			}
+			initial_commit["sig"] = crypto.raw_sign(
+				privkey, cbrrr.encode_dag_cbor(initial_commit)
+			)
+			commit_bytes = cbrrr.encode_dag_cbor(initial_commit)
+			commit_cid = cbrrr.CID.cidv1_dag_cbor_sha256_32_from(commit_bytes)
+
+			db.con.execute(
+				"""
+				INSERT INTO user(
+					did,
+					handle,
+					prefs,
+					pw_hash,
+					signing_key,
+					head,
+					rev,
+					commit_bytes
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+				""",
+				(
+					test_did,
+					test_handle,
+					b'{"preferences":[]}',
+					hardcoded_hash,  # Use hardcoded hash instead of hashing password
+					privkey_pem,
+					bytes(commit_cid),
+					tid,
+					commit_bytes,
+				),
+			)
+			user_id = db.con.last_insert_rowid()
+			db.con.execute(
+				"INSERT INTO mst(repo, cid, since, value) VALUES (?, ?, ?, ?)",
+				(user_id, bytes(empty_mst.cid), tid, empty_mst.serialised),
+			)
+
+		# Verify login works with the hardcoded hash
+		did, handle = db.verify_account_login(test_handle, test_password)
+		assert did == test_did
+		assert handle == test_handle
+
+		# Also verify login works with DID
+		did, handle = db.verify_account_login(test_did, test_password)
+		assert did == test_did
+		assert handle == test_handle
+
+		# Verify wrong password still fails
+		with pytest.raises(ValueError, match="invalid password"):
+			db.verify_account_login(test_handle, "wrong_password")


### PR DESCRIPTION
Switch from argon2-cffi to cryptography's built-in Argon2id implementation to reduce dependencies. The cryptography library was already a required dependency, so this eliminates the need for an additional package.

Changes:
- Use cryptography.hazmat.primitives.kdf.argon2.Argon2id for hashing
- Maintain backward compatibility with existing password hashes
- Add test case with hardcoded argon2-cffi hash to verify compatibility
- Remove argon2-cffi from pyproject.toml dependencies

All existing password hashes continue to work, as both implementations produce and verify PHC-formatted argon2id strings.